### PR TITLE
Split string with considering surrogate pair.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,7 @@ class FuriWord extends React.Component<FuriWordProps, FuriWordState> {
         <View style={[{}, this.props.style]}>
           <Text style={[{ fontSize: furiSize, textAlign: 'center' }, this.props.furiStyle, (!this.props.showFuri ? { opacity: 0 } : {})]}>{this.props.furi ? this.props.furi : ' '}</Text>
           <View style={{ borderColor: 'red', borderWidth: 0, flexDirection: 'row', justifyContent: value.length > 1 ? 'space-between' : 'center' }}>
-            {value.split('').map((item, index) => (
+            {[...value].map((item, index) => (
               <Text key={index} style={[{ fontSize: size }, this.props.valueStyle]}>{item}</Text>
             ))}
           </View>
@@ -72,7 +72,7 @@ export default class Furi extends React.PureComponent<FuriProps, FuriState> {
       if (item.furi)
         nv.push(item)
       else
-        item.value.split('').forEach((item2) => {
+        [...item.value].forEach((item2) => {
           nv.push({ value: item2, furi: '' })
         })
     })


### PR DESCRIPTION
Some Kanji presentations like 𩸽(Hokke: `U+29E3D`) consist of surrogate pairs.

To split string containing Kanji, you should use the way considering surrogate pair like spread syntax.

For example, if you split string containing 𩸽 with `string.split` function, 𩸽 is split in two surrogate bytes.

```javascript
const string_including_surrogate_pair = "𩸽（ホッケ）"

console.log(string_including_surrogate_pair.split(''))
// [ '\ud867', '\ude3d', '（', 'ホ', 'ッ', 'ケ', '）' ]

console.log([...string_including_surrogate_pair])
// [ '𩸽', '（', 'ホ', 'ッ', 'ケ', '）' ]
```

In this PR, I wrote code to split string with spread syntax instead of `string.split`. 
Could you review this?